### PR TITLE
Fix container view position when used with animation and from a storyboa...

### DIFF
--- a/Example/JJTabBarControllerExample/Source/SubTabsVC/ExampleAnimConfigVC.m
+++ b/Example/JJTabBarControllerExample/Source/SubTabsVC/ExampleAnimConfigVC.m
@@ -37,7 +37,7 @@
         case JJTabBarAnimationCrossDissolve:
             return 1;
 
-        case JJTabBarAnimationSlide:
+        case JJTabBarAnimationSlideUp:
             return 2;
 
         default:
@@ -51,7 +51,7 @@
             return JJTabBarAnimationCrossDissolve;
             
         case 2:
-            return JJTabBarAnimationSlide;
+            return JJTabBarAnimationSlideUp;
             
         default:
             return JJTabBarAnimationNone;

--- a/JJTabBarController/containers/JJTabBarController.h
+++ b/JJTabBarController/containers/JJTabBarController.h
@@ -27,7 +27,10 @@ typedef NS_ENUM(short, JJTabBarDock) {
 typedef NS_ENUM(short, JJTabBarAnimation) {
     JJTabBarAnimationNone,
     JJTabBarAnimationCrossDissolve,
-    JJTabBarAnimationSlide,
+    JJTabBarAnimationSlideFromLeft,
+    JJTabBarAnimationSlideFromRight,
+    JJTabBarAnimationSlideUp,
+    JJTabBarAnimationSlideDown,
 };
 
 #define JJTabBarDockIsHorizontal(x) ( (x) == JJTabBarDockBottom || (x) == JJTabBarDockTop )

--- a/JJTabBarController/containers/JJTabBarController.m
+++ b/JJTabBarController/containers/JJTabBarController.m
@@ -86,6 +86,7 @@
 
 - (void)setTabBar:(JJTabBarView *)associatedTabBar {
     _tabBar = associatedTabBar;
+    _tabBarSize = _tabBar.bounds.size;
     
     if ( ![self isViewLoaded] ) {
         return;
@@ -165,7 +166,6 @@
 - (void)viewWillLayoutSubviews {
     _tabBar.frame = [self frameForTabBarWithTabbarHidden:_tabBar.hidden];
     _tabBar.alignment = [self alignmentForTabBar];
-    _viewContainer.frame = [self frameForContainerWithTabbarHidden:(_tabBar ? _tabBar.hidden : NO)];
     self.selectedTabBarChild.view.frame = _viewContainer.bounds;
 }
 

--- a/JJTabBarController/containers/JJTabBarController.m
+++ b/JJTabBarController/containers/JJTabBarController.m
@@ -10,6 +10,13 @@
 #import <objc/runtime.h>
 #import "JJTabBarSegue.h"
 
+BOOL isSlideAnimation(JJTabBarAnimation animation) {
+    return  (animation == JJTabBarAnimationSlideUp ||
+             animation == JJTabBarAnimationSlideDown ||
+             animation == JJTabBarAnimationSlideFromLeft ||
+             animation == JJTabBarAnimationSlideFromRight);
+}
+
 @interface JJTabBarController () <JJButtonMatrixDelegate>
 
 @property(nonatomic,assign) CGSize tabBarSize;
@@ -249,7 +256,7 @@
             self.tabBar.frame = frame;
             self.tabBar.alpha = (hiddenTabBar ? 1.0f : 0.0f);
 
-        }else if ( animation == JJTabBarAnimationSlide ) {
+        }else if ( isSlideAnimation(animation)) {
             frame = [self frameForTabBarWithTabbarHidden:!_hiddenTabBar];
             self.tabBar.frame = frame;
             self.tabBar.alpha = 1.0f;
@@ -259,7 +266,7 @@
         
         [UIView animateWithDuration:0.3f delay:0.0f options:options animations:^{
             
-            if ( animation == JJTabBarAnimationSlide ) {
+            if ( isSlideAnimation(animation) ) {
                 CGRect frame = [self frameForTabBarWithTabbarHidden:_hiddenTabBar];
                 self.tabBar.frame = frame;
             } else if ( animation == JJTabBarAnimationCrossDissolve ) {
@@ -524,7 +531,8 @@
         if ( animation == JJTabBarAnimationCrossDissolve ) {
             options |= UIViewAnimationOptionTransitionCrossDissolve;
             
-        } else if ( animation == JJTabBarAnimationSlide ) {
+        }
+        else if ( animation == JJTabBarAnimationSlideDown ) {
             
             CGRect initialFrame = self.viewContainer.bounds;
             switch (self.tabBarDock) {
@@ -549,13 +557,88 @@
             }
             viewController.view.frame = initialFrame;
         }
+        else if ( animation == JJTabBarAnimationSlideUp ) {
+            
+            CGRect initialFrame = self.viewContainer.bounds;
+            switch (self.tabBarDock) {
+                case JJTabBarDockTop:
+                    initialFrame.origin.y += initialFrame.size.height;
+                    break;
+                    
+                case JJTabBarDockBottom:
+                    initialFrame.origin.y -= initialFrame.size.height;
+                    break;
+                    
+                case JJTabBarDockLeft:
+                    initialFrame.origin.x += initialFrame.size.width;
+                    break;
+                    
+                case JJTabBarDockRight:
+                    initialFrame.origin.x -= initialFrame.size.width;
+                    break;
+                    
+                default:
+                    break;
+            }
+            viewController.view.frame = initialFrame;
+        }
+        else if ( animation == JJTabBarAnimationSlideFromRight ) {
+            
+            CGRect initialFrame = self.viewContainer.bounds;
+            switch (self.tabBarDock) {
+                case JJTabBarDockTop:
+                    initialFrame.origin.x -= initialFrame.size.width;
+                    break;
+                    
+                case JJTabBarDockBottom:
+                    initialFrame.origin.x += initialFrame.size.width;
+                    break;
+                    
+                case JJTabBarDockLeft:
+                    initialFrame.origin.y -= initialFrame.size.height;
+                    break;
+                    
+                case JJTabBarDockRight:
+                    initialFrame.origin.y += initialFrame.size.height;
+                    break;
+                    
+                default:
+                    break;
+            }
+            viewController.view.frame = initialFrame;
+        }
+        else if ( animation == JJTabBarAnimationSlideFromRight ) {
+            
+            CGRect initialFrame = self.viewContainer.bounds;
+            switch (self.tabBarDock) {
+                case JJTabBarDockTop:
+                    initialFrame.origin.x += initialFrame.size.width;
+                    break;
+                    
+                case JJTabBarDockBottom:
+                    initialFrame.origin.x -= initialFrame.size.width;
+                    break;
+                    
+                case JJTabBarDockLeft:
+                    initialFrame.origin.y += initialFrame.size.height;
+                    break;
+                    
+                case JJTabBarDockRight:
+                    initialFrame.origin.y -= initialFrame.size.height;
+                    break;
+                    
+                default:
+                    break;
+            }
+            viewController.view.frame = initialFrame;
+        }
         
         [self transitionFromViewController:_selectedTabBarChild
                           toViewController:viewController
                                   duration:0.3
                                    options:options
                                 animations:^{
-                                    if ( animation == JJTabBarAnimationSlide ) {
+                                    if ( isSlideAnimation(animation) ) {
                                         CGRect finalFrame = self.viewContainer.bounds;
                                         viewController.view.frame = finalFrame;
                                     }


### PR DESCRIPTION
...rd.

When created using storyboard, the property tabBarFrame is CGSizeZero. It was also wrongly repositioning viewContainer frame, not considering tabor size correctly. The error was caught when tab bar is above container view, and the size (width and/or height) of the tab bar plus container view is less then the size of the view controller that contains both.
